### PR TITLE
Various minor fixes

### DIFF
--- a/src/main/java/com/github/katjahahn/parser/MemoryMappedPE.scala
+++ b/src/main/java/com/github/katjahahn/parser/MemoryMappedPE.scala
@@ -66,7 +66,7 @@ class MemoryMappedPE(
   def physToVirtAddress(physAddr: Long): Long = {
     val addresses = _physToVirtAddresses(physAddr)
     // VA doesn't exist, return -1
-    if (addresses.size == 0) -1
+    if (addresses.isEmpty) -1
     else {
       if (addresses.size > 1) {
         logger.warn(s"Caution: Several mappings for the file offset (${hex(physAddr)}) found.")
@@ -106,7 +106,7 @@ class MemoryMappedPE(
   def virtToPhysAddress(va: Long): Long = {
     val addresses = _virtToPhysAddresses(va)
     // VA doesn't exist, return -1
-    if (addresses.size == 0) -1
+    if (addresses.isEmpty) -1
     else {
       if (addresses.size > 1) {
         logger.warn(s"Caution: Several mappings for the VA (${hex(va)}) found, that means the VA is overwritten.")

--- a/src/main/java/com/github/katjahahn/parser/sections/SectionLoader.java
+++ b/src/main/java/com/github/katjahahn/parser/sections/SectionLoader.java
@@ -173,7 +173,7 @@ public class SectionLoader {
     }
 
     /**
-     * Determines the the number of bytes that is read for the section.
+     * Determines the number of bytes that is read for the section.
      * <p>
      * This is the actual section size.
      * 

--- a/src/main/java/com/github/katjahahn/parser/sections/debug/DebugType.java
+++ b/src/main/java/com/github/katjahahn/parser/sections/debug/DebugType.java
@@ -10,7 +10,7 @@ import com.github.katjahahn.parser.Characteristic;
  */
 public enum DebugType implements Characteristic {
     /**
-     * Unkown value
+     * Unknown value
      */
     UNKNOWN(0, "Unknown value"),
     /**

--- a/src/main/java/com/github/katjahahn/parser/sections/edata/ExportSection.scala
+++ b/src/main/java/com/github/katjahahn/parser/sections/edata/ExportSection.scala
@@ -50,7 +50,7 @@ import scala.collection.mutable.ListBuffer
  * Creates an export section instance
  * @param edataTable the data directory table
  * @param exportAddressTable contains addresses to exported functions
- * @param namePointerTable containes addresses to names of exported functions
+ * @param namePointerTable contains addresses to names of exported functions
  * @param ordinalTable contains ordinal number of exported functions
  */
 class ExportSection private (
@@ -185,7 +185,7 @@ class ExportSection private (
 
 object ExportSection {
 
-  private val logger = LogManager.getLogger(ExportSection.getClass().getName());
+  private val logger = LogManager.getLogger(ExportSection.getClass().getName())
 
   val maxNameEntries = 5000
   val maxOrdEntries = 5000
@@ -197,7 +197,7 @@ object ExportSection {
     invalidExportCount = 0
     val mmBytes = li.memoryMapped
     val offset = li.fileOffset
-    val exportBytes = mmBytes.slice(li.va, mmBytes.length + li.va);
+    val exportBytes = mmBytes.slice(li.va, mmBytes.length + li.va)
     val edataTable = ExportDirectory(exportBytes, offset)
     val exportAddressTable = loadExportAddressTable(edataTable, mmBytes, li.va, offset)
     val namePointerTable = loadNamePointerTable(edataTable, mmBytes, li.va, offset)

--- a/src/main/java/com/github/katjahahn/parser/sections/idata/ImportSection.scala
+++ b/src/main/java/com/github/katjahahn/parser/sections/idata/ImportSection.scala
@@ -184,7 +184,7 @@ object ImportSection {
         }
         offset += EntrySize
         relOffset += EntrySize
-        if (relOffsetMax < relOffset) relOffsetMax = relOffset;
+        if (relOffsetMax < relOffset) relOffsetMax = relOffset
       } while (!entry.isInstanceOf[NullEntry] && entryCounter < importMax)
     }
   }

--- a/src/main/java/com/github/katjahahn/parser/sections/reloc/BaseRelocBlock.scala
+++ b/src/main/java/com/github/katjahahn/parser/sections/reloc/BaseRelocBlock.scala
@@ -34,7 +34,7 @@ class BlockEntry(val relocType: RelocType, val offset: Long) {
 
 object BlockEntry {
 
-  private val logger = LogManager.getLogger(BlockEntry.getClass().getName());
+  private val logger = LogManager.getLogger(BlockEntry.getClass().getName())
 
   def apply(value: Int): BlockEntry = {
     val typeMask = 0xf000

--- a/src/main/java/com/github/katjahahn/parser/sections/rsrc/ResourceDirectory.scala
+++ b/src/main/java/com/github/katjahahn/parser/sections/rsrc/ResourceDirectory.scala
@@ -171,17 +171,17 @@ object ResourceDirectory {
    */
   type Header = Map[ResourceDirectoryKey, StandardField]
 
-  private val logger = LogManager.getLogger(ResourceDirectory.getClass().getName());
+  private val logger = LogManager.getLogger(ResourceDirectory.getClass().getName())
 
   /**
    * The size of a resource directory entry
    */
-  private val entrySize = 8;
+  private val entrySize = 8
 
   /**
    * The size of the resource directory header
    */
-  private val resourceDirSize = 16;
+  private val resourceDirSize = 16
 
   /**
    * The name of resource directory specification file
@@ -269,7 +269,7 @@ object ResourceDirectory {
     val entriesSum = nameEntries + idEntries
     // we limit the number to maximum if reached
     val limitedEntriesSum = if (entriesSum < entryMaximum) entriesSum else entryMaximum
-    var entries = ListBuffer.empty[ResourceDirectoryEntry]
+    val entries = ListBuffer.empty[ResourceDirectoryEntry]
     try {
       for (i <- 0 until limitedEntriesSum) {
         // calculate the offset for the entry
@@ -293,7 +293,7 @@ object ResourceDirectory {
       }
     } catch {
       case e: IllegalArgumentException =>
-        logger.warn(e.getMessage());
+        logger.warn(e.getMessage())
     }
     entries.toList
   }

--- a/src/main/java/com/github/katjahahn/parser/sections/rsrc/ResourceDirectoryEntry.scala
+++ b/src/main/java/com/github/katjahahn/parser/sections/rsrc/ResourceDirectoryEntry.scala
@@ -123,13 +123,12 @@ case class Name(rva: Long, name: String) extends IDOrName {
 
 object ResourceDirectoryEntry {
 
-  private val logger = LogManager
-    .getLogger(ResourceDirectoryEntry.getClass().getName());
+  private val logger = LogManager.getLogger(ResourceDirectoryEntry.getClass().getName())
 
   /**
    * The specification file name of the resource directory entry
    */
-  private val specLocation = "resourcedirentryspec";
+  private val specLocation = "resourcedirentryspec"
 
   /**
    * The specification file name of the resource type

--- a/src/main/java/com/github/katjahahn/tools/FileScoring.scala
+++ b/src/main/java/com/github/katjahahn/tools/FileScoring.scala
@@ -206,7 +206,7 @@ object FileScoring {
         val file = new File(filename)
         println("input file: " + filename)
         if (!file.exists()) {
-          System.err.println("file doesn't exist!");
+          System.err.println("file doesn't exist!")
         } else {
           println("scanning file ...")
           val prob = FileScoring(file).malwareProbability
@@ -214,7 +214,7 @@ object FileScoring {
           println("-done-")
         }
       } catch {
-        case e: Exception => System.err.println(e.getMessage());
+        case e: Exception => System.err.println(e.getMessage())
       }
     } else if (options.contains('directory)) {
       try {
@@ -222,7 +222,7 @@ object FileScoring {
         val folder = new File(foldername)
         println("input folder: " + foldername)
         if (!folder.exists()) {
-          System.err.println("folder doesn't exist!");
+          System.err.println("folder doesn't exist!")
         } else {
           println("scanning files ...")
           for (file <- folder.listFiles()) {
@@ -236,7 +236,7 @@ object FileScoring {
           println("-done-")
         }
       } catch {
-        case e: Exception => System.err.println(e.getMessage());
+        case e: Exception => System.err.println(e.getMessage())
       }
 
     } else {
@@ -295,8 +295,8 @@ object FileScoring {
           printCounts(bscoreCounter, bscoreClassifiedCounter, total, classifyable)
         }
       } catch {
-        case e: FileFormatException => notLoaded += 1; System.err.println("file is no PE file: " + file.getName());
-        case e: Exception => notLoaded += 1; e.printStackTrace();
+        case e: FileFormatException => notLoaded += 1; System.err.println("file is no PE file: " + file.getName())
+        case e: Exception => notLoaded += 1; e.printStackTrace()
       }
     }
     total -= notLoaded

--- a/src/main/java/com/github/katjahahn/tools/ReportCreator.scala
+++ b/src/main/java/com/github/katjahahn/tools/ReportCreator.scala
@@ -336,7 +336,7 @@ class ReportCreator(private val data: PEData) {
     val table = data.getSectionTable
     val allSections = table.getSectionHeaders.asScala
     val loader = new SectionLoader(data)
-    val build = new StringBuilder();
+    val build = new StringBuilder()
     build.append(title("Section Table"))
     for (secs <- allSections.grouped(maxSec).toList) {
       val sections = secs.toList

--- a/src/main/java/com/github/katjahahn/tools/StringExtractor.scala
+++ b/src/main/java/com/github/katjahahn/tools/StringExtractor.scala
@@ -101,7 +101,7 @@ object StringExtractor {
     // read and save bytes as long as they fulfill f
     while (byte != -1 && f(byte)) {
       str.append(byte.toChar)
-      byte = is.read();
+      byte = is.read()
     }
     // return string and last read byte
     (str.toString(), byte)

--- a/src/main/java/com/github/katjahahn/tools/anomalies/AnomalySubType.java
+++ b/src/main/java/com/github/katjahahn/tools/anomalies/AnomalySubType.java
@@ -232,7 +232,7 @@ public enum AnomalySubType {
      */
     TOO_LARGE_SIZE_OF_RAW(WRONG),
     /**
-     * Contraints for extendec reloc have been violated.
+     * Constraints for extended reloc have been violated.
      */
     EXTENDED_RELOC_VIOLATIONS(WRONG),
     /**

--- a/src/main/java/com/github/katjahahn/tools/anomalies/ExportSectionScanning.scala
+++ b/src/main/java/com/github/katjahahn/tools/anomalies/ExportSectionScanning.scala
@@ -52,7 +52,7 @@ trait ExportSectionScanning extends AnomalyScanner {
       }
       val fractions = locs.filter(!isWithinEData(_)).toList
       if (!fractions.isEmpty) {
-        val description = s"Exports are fractionated!"
+        val description = "Exports are fractionated!"
         anomalyList += StructureAnomaly(PEStructureKey.EXPORT_SECTION, description,
           AnomalySubType.FRACTIONATED_DATADIR, fractions)
 

--- a/src/main/java/com/github/katjahahn/tools/anomalies/ImportSectionScanning.scala
+++ b/src/main/java/com/github/katjahahn/tools/anomalies/ImportSectionScanning.scala
@@ -63,7 +63,7 @@ trait ImportSectionScanning extends AnomalyScanner {
       val fractions = locs.filter(!isWithinIData(_)).toList
       if (!fractions.isEmpty) {
         val affectedImports = idata.getImports.asScala.filter(i =>
-          i.getLocations.asScala.filter(!isWithinIData(_)).size > 0).toList
+          i.getLocations.asScala.exists(!isWithinIData(_))).toList
         val description = s"Imports are fractionated! Affected import DLLs: ${affectedImports.map(_.getName()).mkString(", ")}"
         anomalyList += ImportAnomaly(affectedImports, description,
           AnomalySubType.FRACTIONATED_DATADIR, PEStructureKey.IMPORT_SECTION)

--- a/src/main/java/com/github/katjahahn/tools/anomalies/MSDOSHeaderScanning.scala
+++ b/src/main/java/com/github/katjahahn/tools/anomalies/MSDOSHeaderScanning.scala
@@ -80,7 +80,7 @@ trait MSDOSHeaderScanning extends AnomalyScanner {
     val entries = msdos.getHeaderEntries.asScala
     for(entry <- entries) {
       if(entry.getDescription.contains("Reserved")) {
-        val description = s"MSDOS Header: Reserved field set: " + entry.getDescription
+        val description = "MSDOS Header: Reserved field set: " + entry.getDescription
         anomalyList += FieldAnomaly(entry, description, AnomalySubType.RESERVED_MSDOS_FIELD)
       }
     }

--- a/src/main/java/com/github/katjahahn/tools/anomalies/OptionalHeaderScanning.scala
+++ b/src/main/java/com/github/katjahahn/tools/anomalies/OptionalHeaderScanning.scala
@@ -301,7 +301,7 @@ trait OptionalHeaderScanning extends AnomalyScanner {
       anomalyList += FieldAnomaly(entry, description, TOO_LARGE_IMAGE_BASE)
     }
     if (imageBase == 0) {
-      val description = s"Optional Header: The image base is 0, thus relocated to 0x10000"
+      val description = "Optional Header: The image base is 0, thus relocated to 0x10000"
       anomalyList += FieldAnomaly(entry, description, ZERO_IMAGE_BASE)
     }
     if (isDLL() && imageBase != 0x10000000L) {

--- a/src/main/java/com/github/katjahahn/tools/anomalies/ResourceSectionScanning.scala
+++ b/src/main/java/com/github/katjahahn/tools/anomalies/ResourceSectionScanning.scala
@@ -54,7 +54,7 @@ trait ResourceSectionScanning extends AnomalyScanner {
       }
       val fractions = locs.filter(!isWithinEData(_)).toList
       if (!fractions.isEmpty) {
-        val description = s"Resources are fractionated!"
+        val description = "Resources are fractionated!"
         anomalyList += StructureAnomaly(PEStructureKey.RESOURCE_SECTION, description,
           AnomalySubType.FRACTIONATED_DATADIR, fractions)
 

--- a/src/main/java/com/github/katjahahn/tools/anomalies/SectionTableScanning.scala
+++ b/src/main/java/com/github/katjahahn/tools/anomalies/SectionTableScanning.scala
@@ -206,7 +206,7 @@ trait SectionTableScanning extends AnomalyScanner {
         anomalyList += new SectionNameAnomaly(section, description, CTRL_SYMB_IN_SEC_NAME)
       }
       if (!usualNames.contains(section.getName)) {
-        val description = s"Section name is unusual: ${sectionName}";
+        val description = s"Section name is unusual: ${sectionName}"
         anomalyList += new SectionNameAnomaly(section, description, UNUSUAL_SEC_NAME)
       }
     }

--- a/src/main/java/com/github/katjahahn/tools/sigscanner/Jar2ExeScanner.scala
+++ b/src/main/java/com/github/katjahahn/tools/sigscanner/Jar2ExeScanner.scala
@@ -73,7 +73,7 @@ class Jar2ExeScanner(file: File) {
     val raf = new RandomAccessFile(file, "r")
     val is = Channels.newInputStream(raf.getChannel().position(pos))
     val zis = new ZipInputStream(is)
-    var entries = new ListBuffer[String]()
+    val entries = new ListBuffer[String]()
     try {
       var e = zis.getNextEntry()
       while (e != null) {
@@ -82,9 +82,9 @@ class Jar2ExeScanner(file: File) {
       }
     } catch {
       case e: IllegalArgumentException => return Nil
-      case e: Exception => //System.err.println(e.getMessage());
+      case e: Exception => //System.err.println(e.getMessage())
     } finally {
-      zis.close();
+      zis.close()
     }
     entries.toList
   }
@@ -95,7 +95,7 @@ class Jar2ExeScanner(file: File) {
    * @return scan report
    */
   def createReport(): String = {
-    if (scanResult.length == 0) return "no indication for java wrapper found"
+    if (scanResult.isEmpty) return "no indication for java wrapper found"
     var lastName = ""
     val sigs = (for ((sig, addr) <- scanResult) yield {
       var str = new StringBuilder()
@@ -111,7 +111,7 @@ class Jar2ExeScanner(file: File) {
 
     val addresses = if (scanResult.contains("[CAFEBABE]")) {
       ".class offsets: " + classAddr.mkString(", ") + "\n"
-    } else if (zipAddr.length > 0) {
+    } else if (zipAddr.nonEmpty) {
       "ZIP/Jar offsets: " + zipAddr.mkString(", ") + "\n"
     } else ""
 
@@ -200,8 +200,8 @@ object Jar2ExeScanner {
     codec.onMalformedInput(CodingErrorAction.REPLACE)
     codec.onUnmappableCharacter(CodingErrorAction.REPLACE)
 
-    var sigs = ListBuffer[Signature]()
-    var is = this.getClass().getResourceAsStream(defaultSigs)
+    val sigs = ListBuffer[Signature]()
+    val is = this.getClass().getResourceAsStream(defaultSigs)
     val it = scala.io.Source.fromInputStream(is)(codec).getLines
     while (it.hasNext) {
       val line = it.next

--- a/src/main/java/com/github/katjahahn/tools/sigscanner/SignatureScanner.scala
+++ b/src/main/java/com/github/katjahahn/tools/sigscanner/SignatureScanner.scala
@@ -48,7 +48,7 @@ import SignatureScanner._
  */
 class SignatureScanner(signatures: List[Signature]) {
 
-  val logger = LogManager.getLogger(SignatureScanner.getClass.getName);
+  val logger = LogManager.getLogger(SignatureScanner.getClass.getName)
   /**
    * Creates a SignatureScanner that uses the signatures applied
    * @param signatures to use for scanning
@@ -244,8 +244,8 @@ object SignatureScanner {
     codec.onMalformedInput(CodingErrorAction.REPLACE)
     codec.onUnmappableCharacter(CodingErrorAction.REPLACE)
 
-    var sigs = ListBuffer[Signature]()
-    var is = this.getClass().getResourceAsStream(defaultSigs)
+    val sigs = ListBuffer[Signature]()
+    val is = this.getClass().getResourceAsStream(defaultSigs)
     val it = scala.io.Source.fromInputStream(is)(codec).getLines
     while (it.hasNext) {
       val line = it.next

--- a/src/test/java/com/github/katjahahn/PortexStats.java
+++ b/src/test/java/com/github/katjahahn/PortexStats.java
@@ -720,7 +720,7 @@ public class PortexStats {
                 + "\ndeprecated: " + anomalies[DEPRECATED.ordinal()]
                 + "\nnon default: " + anomalies[NON_DEFAULT.ordinal()];
 
-        String stats3 = "Anomaly occurance per file (absolute) \n\ntotal files: "
+        String stats3 = "Anomaly occurrence per file (absolute) \n\ntotal files: "
                 + total
                 + "\nstructural: "
                 + anPerFile[STRUCTURE.ordinal()]
@@ -732,7 +732,7 @@ public class PortexStats {
                 + anPerFile[DEPRECATED.ordinal()]
                 + "\nnon default: " + anPerFile[NON_DEFAULT.ordinal()];
 
-        String stats4 = "Anomaly occurance per file in percent \n\ntotal files: "
+        String stats4 = "Anomaly occurrence per file in percent \n\ntotal files: "
                 + total
                 + "\nstructural: "
                 + occPerFile[STRUCTURE.ordinal()]


### PR DESCRIPTION
Hi,
I saw PortEx shared on twitter, and decided to do some static code analysis.

Apart from the minor stuff in the PR there were also two interesting bits, which may be bugs.

Here k is an Array, so toString will return something of the form [Type@address:

    [warn] src/main/java/com/github/katjahahn/tools/anomalies/SectionTableScanning.scala:513: Using toString on type Array is likely unintended.
    [warn]     val alignmentCharacteristics = Arrays.asList(SectionCharacteristic.values).asScala.filter(k => k.toString.contains("IMAGE_SCN_ALIGN")).toList
    [warn]                                                                                                      ^

Here a String is passed to a contains on a List[(Signature, Address)], which I don't think can return true:

    [warn] src/main/java/com/github/katjahahn/tools/sigscanner/Jar2ExeScanner.scala:112: List[(com.github.katjahahn.tools.sigscanner.Signature, com.github.katjahahn.tools.sigscanner.SignatureScanner.Address)].contains(String) will probably return false, since the collection and target element are of unrelated types.
    [warn]     val addresses = if (scanResult.contains("[CAFEBABE]")) {
    [warn]                                    ^

There is also a typo I didn't correct, since it was present in the data as well. Search for UNINIT_DATA_CONTRAINTS_VIOLATION.

Cheers, HairyFotr